### PR TITLE
Pinning Action Dependencies for Security and Reliability

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       release_tag: ${{ steps.vars.outputs.release_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: 'Set output variables'
@@ -42,15 +42,15 @@ jobs:
       labels: [self-hosted, "1ES.Pool=1es-aks-webhook-tls-manager-pool-ubuntu"]
     needs: prepare-variables
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v 4.2.2
         with:
           ref: ${{ needs.prepare-variables.outputs.release_tag }}
 
       - name: 'Set up QEMU (for multi-arch builds)'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: 'Login to Azure Container Registry'
         run: |

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: '1.x'
 

--- a/.github/workflows/test-coverage-check.yml
+++ b/.github/workflows/test-coverage-check.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: '1.x'  # Adjust based on your project requirements
 
@@ -40,7 +40,7 @@ jobs:
           fi
 
       - name: Upload coverage report (optional)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 #v4.6.1
         with:
           name: filtered-coverage
           path: filtered_coverage.out


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows by pinning specific versions of the actions used. This ensures security and reliability in the CI/CD processes.

Updates to GitHub Actions workflows:

* [`.github/workflows/build-publish-mcr.yml`](diffhunk://#diff-662b4d95ffea8edd8486210a3b96aa56dea41e4bc4a17dae8b5ff3451aa00675L25-R25): Updated `actions/checkout` to version `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2), `docker/setup-qemu-action` to version `4574d27a4764455b42196d70a065bc6853246a25` (v3.4.0), and `docker/setup-buildx-action` to version `f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca` (v3.9.0). [[1]](diffhunk://#diff-662b4d95ffea8edd8486210a3b96aa56dea41e4bc4a17dae8b5ff3451aa00675L25-R25) [[2]](diffhunk://#diff-662b4d95ffea8edd8486210a3b96aa56dea41e4bc4a17dae8b5ff3451aa00675L45-R53)

* [`.github/workflows/go-test.yml`](diffhunk://#diff-cb63f6037602c7aa1591d3dca2a9c1870ef95ac59f67aaa90dd9cd1163e20898L14-R17): Updated `actions/checkout` to version `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) and `actions/setup-go` to version `f111f3307d8850f501ac008e886eec1fd1932a34` (v5.3.0).

* [`.github/workflows/test-coverage-check.yml`](diffhunk://#diff-c3c3c28d7e7dc3baa0e7a73e09843a8b558d15f516cce87abeddf16a18bc9784L19-R22): Updated `actions/checkout` to version `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2), `actions/setup-go` to version `f111f3307d8850f501ac008e886eec1fd1932a34` (v5.3.0), and `actions/upload-artifact` to version `4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1` (v4.6.1). [[1]](diffhunk://#diff-c3c3c28d7e7dc3baa0e7a73e09843a8b558d15f516cce87abeddf16a18bc9784L19-R22) [[2]](diffhunk://#diff-c3c3c28d7e7dc3baa0e7a73e09843a8b558d15f516cce87abeddf16a18bc9784L43-R43)