### PR TITLE
bump golang from 1.23.7 to 1.23.8 for CVE fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Azure/webhook-tls-manager
 
 go 1.23.3
 
-toolchain go1.23.7
+toolchain go1.23.8
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
bump golang from 1.23.7 to 1.23.8 for CVE fix