### PR TITLE
bump golang and toolchain to 1.24.2 for CVE fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.3 AS build-stage
+FROM golang:1.24.2 AS build-stage
 
 # Copy dependencies
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/Azure/webhook-tls-manager
 
-go 1.23.3
-
-toolchain go1.23.8
+go 1.24.2
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
Bumped golang version to address following CVEs

CVE-2024-45336
CVE-2024-45341
CVE-2025-22866
CVE-2025-22871