### PR TITLE
Fix test coverage action

### DIFF
--- a/.github/workflows/test-coverage-check.yml
+++ b/.github/workflows/test-coverage-check.yml
@@ -31,13 +31,6 @@ jobs:
           go test -coverprofile=coverage.out ./...
           grep -v -e "/mock_" -e "main.go" -e "/toolkit/log/" -e "/toolkit/certificates/certoperator/" coverage.out > filtered_coverage.out
           go tool cover -func=filtered_coverage.out | tail -n 1 | awk '{print $3}' | sed 's/%//' > coverage.txt
-      
-      - name: Copy coverage to workspace for local debugging
-        run: |
-          mkdir -p /github/workspace/coverage-out
-          cp coverage.out filtered_coverage.out coverage.txt /github/workspace/coverage-out/
-          cp filtered_coverage.out /github/workspace/
-          cp coverage.txt /github/workspace/
 
       - name: Fail if coverage is below threshold
         id: check_coverage

--- a/.github/workflows/test-coverage-check.yml
+++ b/.github/workflows/test-coverage-check.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           go test -coverprofile=coverage.out ./...
-          grep -v -e "/mock_" -e "main.go" -e "/toolkit/" coverage.out > filtered_coverage.out
+          grep -v -e "/mock_" -e "main.go" -e "/toolkit/log/" -e "/toolkit/certificates/certoperator/" coverage.out > filtered_coverage.out
           go tool cover -func=filtered_coverage.out | tail -n 1 | awk '{print $3}' | sed 's/%//' > coverage.txt
       
       - name: Copy coverage to workspace for local debugging

--- a/.github/workflows/test-coverage-check.yml
+++ b/.github/workflows/test-coverage-check.yml
@@ -23,11 +23,21 @@ jobs:
         with:
           go-version: '1.x'  # Adjust based on your project requirements
 
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y bc
+
       - name: Run tests with coverage
         run: |
           go test -coverprofile=coverage.out ./...
-          grep -v -e "/mock_" -e "main.go" -e "toolkit/log/span.go" coverage.out > filtered_coverage.out
+          grep -v -e "/mock_" -e "main.go" -e "/toolkit/" coverage.out > filtered_coverage.out
           go tool cover -func=filtered_coverage.out | tail -n 1 | awk '{print $3}' | sed 's/%//' > coverage.txt
+      
+      - name: Copy coverage to workspace for local debugging
+        run: |
+          mkdir -p /github/workspace/coverage-out
+          cp coverage.out filtered_coverage.out coverage.txt /github/workspace/coverage-out/
+          cp filtered_coverage.out /github/workspace/
+          cp coverage.txt /github/workspace/
 
       - name: Fail if coverage is below threshold
         id: check_coverage

--- a/config/config.go
+++ b/config/config.go
@@ -36,3 +36,27 @@ func UpdateConfig(objectName string, caValidityYears int, serverValidityYears in
 		AppConfig.Namespace = namespace
 	}
 }
+
+func SecretName() string {
+	return AppConfig.ObjectName + "-tls-certs"
+}
+
+func WebhookConfigName() string {
+	return AppConfig.ObjectName + "-webhook-config"
+}
+
+func ServiceName() string {
+	return AppConfig.ObjectName + "-webhook"
+}
+
+func CACertificateCommonName() string {
+	return AppConfig.ObjectName + "_webhook_ca"
+}
+
+func ServerCertificateCommonName() string {
+	return AppConfig.ObjectName + "-webhook." + AppConfig.Namespace + ".svc"
+}
+
+func MetricsPrefix() string {
+	return AppConfig.ObjectName + "_metrics"
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,4 +25,46 @@ func TestConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("SecretName", func(t *testing.T) {
+		expected := "webhook-tls-manager-tls-certs"
+		if SecretName() != expected {
+			t.Errorf("expected %s, got %s", expected, SecretName())
+		}
+	})
+
+	t.Run("WebhookConfigName", func(t *testing.T) {
+		expected := "webhook-tls-manager-webhook-config"
+		if WebhookConfigName() != expected {
+			t.Errorf("expected %s, got %s", expected, WebhookConfigName())
+		}
+	})
+
+	t.Run("ServiceName", func(t *testing.T) {
+		expected := "webhook-tls-manager-webhook"
+		if ServiceName() != expected {
+			t.Errorf("expected %s, got %s", expected, ServiceName())
+		}
+	})
+
+	t.Run("CACertificateCommonName", func(t *testing.T) {
+		expected := "webhook-tls-manager_webhook_ca"
+		if CACertificateCommonName() != expected {
+			t.Errorf("expected %s, got %s", expected, CACertificateCommonName())
+		}
+	})
+
+	t.Run("ServerCertificateCommonName", func(t *testing.T) {
+		expected := "webhook-tls-manager-webhook.kube-system.svc"
+		if ServerCertificateCommonName() != expected {
+			t.Errorf("expected %s, got %s", expected, ServerCertificateCommonName())
+		}
+	})
+
+	t.Run("MetricsPrefix", func(t *testing.T) {
+		expected := "webhook-tls-manager_metrics"
+		if MetricsPrefix() != expected {
+			t.Errorf("expected %s, got %s", expected, MetricsPrefix())
+		}
+	})
+
 }

--- a/goalresolvers/goal_resolver_test.go
+++ b/goalresolvers/goal_resolver_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/webhook-tls-manager/consts"
 	"github.com/Azure/webhook-tls-manager/toolkit/certificates"
 	"github.com/Azure/webhook-tls-manager/toolkit/log"
-	"github.com/Azure/webhook-tls-manager/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -74,7 +73,7 @@ var _ = Describe("shouldRotateCert", func() {
 				APIVersion: "v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      utils.SecretName(),
+				Name:      config.SecretName(),
 				Namespace: config.AppConfig.Namespace,
 			},
 			Data: map[string][]byte{},
@@ -161,7 +160,7 @@ func generateSecret(cert string, namespace string) *corev1.Secret {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      utils.SecretName(),
+			Name:      config.SecretName(),
 			Namespace: namespace,
 			Labels: map[string]string{
 				consts.ManagedLabelKey: consts.ManagedLabelValue,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,15 +1,14 @@
 package metrics
 
 import (
+	"github.com/Azure/webhook-tls-manager/config"
 	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/Azure/webhook-tls-manager/utils"
 )
 
 var (
 	ResultMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Subsystem: utils.MetricsPrefix(),
+			Subsystem: config.MetricsPrefix(),
 			Name:      "webhook_job_succeed",
 			Help:      "Result of webhook job, 1 is failed and 0 is successful",
 		},
@@ -17,7 +16,7 @@ var (
 	)
 	RotateCertificateMetric = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Subsystem: utils.MetricsPrefix(),
+			Subsystem: config.MetricsPrefix(),
 			Name:      "rotate_certificate_result",
 			Help:      "Whether or not to rotate certificate, 0 is not rotate and 1 is rotate",
 		},

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"testing"
 
-	"github.com/Azure/webhook-tls-manager/utils"
+	"github.com/Azure/webhook-tls-manager/config"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	metricName := utils.MetricsPrefix() + "_rotate_certificate_result"
+	metricName := config.MetricsPrefix() + "_rotate_certificate_result"
 	mf, err := prometheus.DefaultGatherer.Gather()
 	require.NoError(t, err)
 	metric := getMetrics(mf, metricName)

--- a/reconcilers/reconciler_test.go
+++ b/reconcilers/reconciler_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Azure/webhook-tls-manager/goalresolvers/mock_goal_resolvers"
 	"github.com/Azure/webhook-tls-manager/metrics"
 	"github.com/Azure/webhook-tls-manager/toolkit/log"
-	"github.com/Azure/webhook-tls-manager/utils"
 )
 
 const (
@@ -201,7 +200,7 @@ var _ = Describe("createOrUpdateSecret", func() {
 	It("secret not exists and create secret succeed", func() {
 		cerr := createOrUpdateSecret(ctx, fakeClientset, data)
 		Expect(cerr).To(BeNil())
-		secret, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, utils.SecretName(), metav1.GetOptions{})
+		secret, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, config.SecretName(), metav1.GetOptions{})
 		Expect(err).To(BeNil())
 		Expect(secret.Data["caCert.pem"]).To(BeEquivalentTo("caCert"))
 	})
@@ -230,7 +229,7 @@ var _ = Describe("createOrUpdateSecret", func() {
 		fakeClientset = fake.NewSimpleClientset(s, prepareCM(config.AppConfig.Namespace))
 		cerr := createOrUpdateSecret(ctx, fakeClientset, data)
 		Expect(cerr).To(BeNil())
-		secret, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, utils.SecretName(), metav1.GetOptions{})
+		secret, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, config.SecretName(), metav1.GetOptions{})
 		Expect(err).To(BeNil())
 		Expect(secret.Data["caCert.pem"]).To(BeEquivalentTo("caCert"))
 	})
@@ -269,7 +268,7 @@ var _ = Describe("createOrUpdateWebhook", func() {
 	It("create webhook succeed", func() {
 		cerr := createOrUpdateWebhook(ctx, client, false)
 		Expect(cerr).To(BeNil())
-		webhook, res := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, utils.WebhookConfigName(), metav1.GetOptions{})
+		webhook, res := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, config.WebhookConfigName(), metav1.GetOptions{})
 		Expect(res).To(BeNil())
 		Expect(webhook).NotTo(BeNil())
 	})
@@ -287,7 +286,7 @@ var _ = Describe("createOrUpdateWebhook", func() {
 		client = fake.NewSimpleClientset(mutatingWebhookConfiguration(true), secret(config.AppConfig.Namespace), prepareCM(config.AppConfig.Namespace))
 		cerr := createOrUpdateWebhook(ctx, client, false)
 		Expect(cerr).To(BeNil())
-		webhook, res := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, utils.WebhookConfigName(), metav1.GetOptions{})
+		webhook, res := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, config.WebhookConfigName(), metav1.GetOptions{})
 		Expect(res).To(BeNil())
 		Expect(webhook).NotTo(BeNil())
 		Expect(webhook.ObjectMeta.Labels[consts.AdmissionEnforcerDisabledLabel]).To(BeEquivalentTo(consts.AdmissionEnforcerDisabledValue))
@@ -296,7 +295,7 @@ var _ = Describe("createOrUpdateWebhook", func() {
 	It("webhook not managed by aks exists", func() {
 		webhookConfig := &admissionregistration.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: utils.WebhookConfigName(),
+				Name: config.WebhookConfigName(),
 				Labels: map[string]string{
 					consts.ManagedLabelKey: "non-aks",
 				},
@@ -305,7 +304,7 @@ var _ = Describe("createOrUpdateWebhook", func() {
 		client = fake.NewSimpleClientset(webhookConfig, secret(config.AppConfig.Namespace), prepareCM(config.AppConfig.Namespace))
 		cerr := createOrUpdateWebhook(ctx, client, false)
 		Expect(cerr).To(BeNil())
-		webhook, res := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, utils.WebhookConfigName(), metav1.GetOptions{})
+		webhook, res := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, config.WebhookConfigName(), metav1.GetOptions{})
 		Expect(res).To(BeNil())
 		Expect(webhook).NotTo(BeNil())
 		Expect(webhook.Labels[consts.ManagedLabelKey]).To(BeEquivalentTo("non-aks"))
@@ -334,7 +333,7 @@ var _ = Describe("cleanupSecretAndWebhook", func() {
 	It("delete webhook error", func() {
 		fakeClientset = fake.NewSimpleClientset(secret(config.AppConfig.Namespace), prepareCM(config.AppConfig.Namespace))
 		cerr := cleanupSecretAndWebhook(ctx, fakeClientset)
-		_, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, utils.SecretName(), metav1.GetOptions{})
+		_, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, config.SecretName(), metav1.GetOptions{})
 		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 		Expect(cerr).Error()
 	})
@@ -366,7 +365,7 @@ var _ = Describe("createTlsSecret", func() {
 	It("no secret exists", func() {
 		cerr := createTlsSecret(ctx, fakeClientset, data)
 		Expect(cerr).To(BeNil())
-		secret, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, utils.SecretName(), metav1.GetOptions{})
+		secret, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, config.SecretName(), metav1.GetOptions{})
 		Expect(err).To(BeNil())
 		Expect(secret).NotTo(BeNil())
 	})
@@ -413,7 +412,7 @@ var _ = Describe("updateTlsSecret", func() {
 		cerr := updateTlsSecret(ctx, fakeClientset, data, s)
 		Expect(cerr).To(BeNil())
 
-		secret, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, utils.SecretName(), metav1.GetOptions{})
+		secret, err := fakeClientset.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, config.SecretName(), metav1.GetOptions{})
 		Expect(err).To(BeNil())
 		Expect(secret.Data["caCert.pem"]).To(BeEquivalentTo("caCert"))
 	})
@@ -503,7 +502,7 @@ var _ = Describe("createMutatingWebhookConfig test", func() {
 		})
 		cerr := createMutatingWebhookConfig(ctx, fakeClientset, caCertPem, true)
 		Expect(cerr).NotTo(BeNil())
-		webhook, err := fakeClientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, utils.WebhookConfigName(), metav1.GetOptions{})
+		webhook, err := fakeClientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, config.WebhookConfigName(), metav1.GetOptions{})
 		Expect(err).NotTo(BeNil())
 		Expect(webhook).To(BeNil())
 	})
@@ -511,7 +510,7 @@ var _ = Describe("createMutatingWebhookConfig test", func() {
 	It("unblock kube-system namespace", func() {
 		cerr := createMutatingWebhookConfig(ctx, fakeClientset, caCertPem, false)
 		Expect(cerr).To(BeNil())
-		webhook, err := fakeClientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, utils.WebhookConfigName(), metav1.GetOptions{})
+		webhook, err := fakeClientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, config.WebhookConfigName(), metav1.GetOptions{})
 		Expect(err).To(BeNil())
 
 		_, keyExist := webhook.ObjectMeta.Labels[consts.AdmissionEnforcerDisabledLabel]
@@ -551,7 +550,7 @@ var _ = Describe("updateMutatingWebhookConfig test", func() {
 		fakeClientset = fake.NewSimpleClientset(webhook, prepareCM(config.AppConfig.Namespace))
 		cerr := updateMutatingWebhookConfig(ctx, fakeClientset, true, []byte{})
 		Expect(cerr).To(BeNil())
-		res, err := fakeClientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, utils.WebhookConfigName(), metav1.GetOptions{})
+		res, err := fakeClientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, config.WebhookConfigName(), metav1.GetOptions{})
 		Expect(err).To(BeNil())
 		_, keyExist := res.Labels[consts.AdmissionEnforcerDisabledLabel]
 		Expect(keyExist).To(BeFalse())
@@ -562,7 +561,7 @@ var _ = Describe("updateMutatingWebhookConfig test", func() {
 		caCert := []byte("test")
 		cerr := updateMutatingWebhookConfig(ctx, fakeClientset, false, caCert)
 		Expect(cerr).To(BeNil())
-		res, err := fakeClientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, utils.WebhookConfigName(), metav1.GetOptions{})
+		res, err := fakeClientset.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, config.WebhookConfigName(), metav1.GetOptions{})
 		Expect(err).To(BeNil())
 		Expect(res.Labels[consts.AdmissionEnforcerDisabledLabel]).To(BeEquivalentTo("true"))
 		Expect(res.Webhooks[0].ClientConfig.CABundle).To(BeEquivalentTo(caCert))
@@ -647,11 +646,11 @@ var _ = Describe("webhook tls manager reconciler reconcile", func() {
 		Expect(cerr).To(BeNil())
 		Expect(testutil.ToFloat64(metrics.RotateCertificateMetric)).To(BeEquivalentTo(1))
 
-		webhook, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, utils.WebhookConfigName(), metav1.GetOptions{})
+		webhook, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, config.WebhookConfigName(), metav1.GetOptions{})
 		Expect(webhook).NotTo(BeNil())
 		Expect(webhook.Webhooks[0].ClientConfig.CABundle).To(BeEquivalentTo(goal.CertData.CaCertPem))
 		Expect(err).To(BeNil())
-		secret, err := client.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, utils.SecretName(), metav1.GetOptions{})
+		secret, err := client.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, config.SecretName(), metav1.GetOptions{})
 		Expect(secret).NotTo(BeNil())
 		Expect(err).To(BeNil())
 	})
@@ -669,10 +668,10 @@ var _ = Describe("webhook tls manager reconciler reconcile", func() {
 
 		Expect(cerr).To(BeNil())
 
-		webhook, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, utils.WebhookConfigName(), metav1.GetOptions{})
+		webhook, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, config.WebhookConfigName(), metav1.GetOptions{})
 		Expect(webhook).NotTo(BeNil())
 		Expect(err).To(BeNil())
-		secret, err := client.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, utils.SecretName(), metav1.GetOptions{})
+		secret, err := client.CoreV1().Secrets(config.AppConfig.Namespace).Get(ctx, config.SecretName(), metav1.GetOptions{})
 		Expect(secret).NotTo(BeNil())
 		Expect(err).To(BeNil())
 	})
@@ -755,7 +754,7 @@ func mutatingWebhookConfiguration(systemNamespaceBlocked bool) *admissionregistr
 			APIVersion: "admissionregistration.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   utils.WebhookConfigName(),
+			Name:   config.WebhookConfigName(),
 			Labels: label,
 		},
 		Webhooks: []admissionregistration.MutatingWebhook{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"github.com/Azure/webhook-tls-manager/config"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/client-go/kubernetes"
 )
@@ -17,28 +16,4 @@ func GetKubeClient() kubernetes.Interface {
 	kubeClient := kubernetes.NewForConfigOrDie(config)
 	var clientInterface kubernetes.Interface = kubeClient
 	return clientInterface
-}
-
-func SecretName() string {
-	return config.AppConfig.ObjectName + "-tls-certs"
-}
-
-func WebhookConfigName() string {
-	return config.AppConfig.ObjectName + "-webhook-config"
-}
-
-func ServiceName() string {
-	return config.AppConfig.ObjectName + "-webhook"
-}
-
-func CACertificateCommonName() string {
-	return config.AppConfig.ObjectName + "_webhook_ca"
-}
-
-func ServerCertificateCommonName() string {
-	return config.AppConfig.ObjectName + "-webhook." + config.AppConfig.Namespace + ".svc"
-}
-
-func MetricsPrefix() string {
-	return config.AppConfig.ObjectName + "_metrics"
 }


### PR DESCRIPTION
There were repeated lines in the unit test coverage report which leads to higher coverage rate.

Exclude log and certoperator pkg from coverage report.