### PR TITLE
bump to go 1.24.6 to fix CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/webhook-tls-manager
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
We got this CVE alert and need to bump go to 1.24.6:
https://portal.microsofticm.com/imp/v5/incidents/details/675994056/summary