### PR TITLE
update gotoolchain to 1.24.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4 AS build-stage
+FROM golang:1.24.6 AS build-stage
 
 # Copy dependencies
 COPY go.mod go.sum ./
@@ -7,7 +7,7 @@ COPY vendor/ vendor/
 # Set working directory
 WORKDIR /app
 
-# Force using the installed Go version (1.23.3) instead of fetching 1.23.7
+# Force using the installed Go version (1.24.6) instead of fetching the one in go.mod
 ENV GOTOOLCHAIN=local
 
 # Copy the entire source code


### PR DESCRIPTION
It failed with `go.mod requires go >= 1.24.6 (running go 1.24.4; GOTOOLCHAIN=local)`

```
#16 [linux/arm64 build-stage 5/6] COPY . .
#16 CANCELED
------
 > [linux/amd64 build-stage 6/6] RUN CGO_ENABLED=0 go build -mod=vendor -o webhook-tls-manager main.go:
0.977 go: warning: ignoring go.mod in $GOPATH /go
0.984 go: go.mod requires go >= 1.24.6 (running go 1.24.4; GOTOOLCHAIN=local)
------
Dockerfile:17
--------------------
  15 |     
  16 |     # Build the Go binary using vendored dependencies
  17 | >>> RUN CGO_ENABLED=0 go build -mod=vendor -o webhook-tls-manager main.go
  18 |     
  19 |     # Minimal final image (scratch for smallest size)
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c CGO_ENABLED=0 go build -mod=vendor -o webhook-tls-manager main.go" did not complete successfully: exit code: 1
```